### PR TITLE
Change SW cache technique

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -6,13 +6,13 @@ self.addEventListener('fetch', function(event) {
 
 function fetchAndCache(event) {
   return caches.open(CACHE).then(function (cache) {
-    return fetch(event.request)
-      .then(function(response) {
-        cache.put(event.request, response.clone());
-        return response;
-      })
-      .catch(function() {
-        return cache.match(event.request);
-      });
+    return cache.match(event.request).then(response => {
+      var fetchResponse = fetch(event.request)
+        .then(function(networkResponse) {
+          cache.put(event.request, networkResponse.clone());
+          return networkResponse;
+        });
+      return response || fetchResponse;
+    });
   });
 }


### PR DESCRIPTION
Return with cache first if it's available, fall back to the network response. Network response is always fetched and the cache updated without having the user wait.