### PR TITLE
Fix bullet alignment for wrapped links in article lists

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -126,6 +126,7 @@ article {
 
   a {
     display: inline-block;
+    vertical-align: top;
   }
 }
 


### PR DESCRIPTION
Inline-block links inside <li> were defaulting to baseline alignment, which for multi-line inline-blocks is the last line-box. That pushed the list marker down next to the link's last line on narrow viewports. Aligning to top keeps the marker beside the first line.

<img width="1080" height="2340" alt="Screenshot_20260523_151053_Vivaldi" src="https://github.com/user-attachments/assets/aa459b76-0600-4540-b381-093ed0ef5b40" />
